### PR TITLE
Updating to .NET 8.0:  Compile and run project with current Visual Code Studio

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceFolder}/src/UFiber.Configurator/bin/Debug/net5.0/UFiber.Configurator.dll",
+            "program": "${workspaceFolder}/src/UFiber.Configurator/bin/Debug/net8.0/UFiber.Configurator.dll",
             "args": [
                 "--host",
                 "192.168.200.2",

--- a/src/UFiber.Configurator/Program.cs
+++ b/src/UFiber.Configurator/Program.cs
@@ -59,8 +59,9 @@ ScpClient GetSCPClient(string userName, string password, string host, int port =
 
 rootCommand.Handler = CommandHandler
     .Create<string, string, string, int, bool, string, string, string, string, string>(
-        (host, user, pw, port, dryRun, slid, vendor, serial, mac, fwToRestore) =>
+        (host, user, pw, port, dryRun, slid, vendor, serial, mac, restore) =>
         {
+            var fwToRestore = restore; 
             if (string.IsNullOrWhiteSpace(host))
             {
                 Console.Error.WriteLine("Host is a required parameter and can't be empty.");

--- a/src/UFiber.Configurator/UFiber.Configurator.csproj
+++ b/src/UFiber.Configurator/UFiber.Configurator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>


### PR DESCRIPTION
I wanted to play around on this project. I use a Mac with Apple Silicon. I downloaded and installed Visual Code Studio 1.92.2 and with surprisingly few edits, was able to get this project up and running. .NET 5.0 seems to be quite old, and is only available in x86_64 from what I could find on the internet. .NET 8.0 is current, and 9.0 is in preview. I assume 9.0 will be another "drop in replacement" but for now, this works well.

This is a base for me, because I want to add support for UFiber Loco 4.4.6 firmware, which I have made a little bit of headway on. 